### PR TITLE
Union types

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 namespace phootwork\fixer;
 
 use PhpCsFixer\Config as BaseConfig;
@@ -13,7 +13,7 @@ class Config extends BaseConfig {
 	}
 
 	public function getRules(): array {
-		return [
+		$rules = [
 			'align_multiline_comment' => [
 				'comment_type' => 'phpdocs_only'
 			],
@@ -86,5 +86,12 @@ class Config extends BaseConfig {
 			'visibility_required' => true,
 			'whitespace_after_comma_in_array' => true
 		];
+
+		if (phpversion() >= '8.0') {
+			//temporary workaround to avoid spaces between PHP 8 union types
+			$rules['binary_operator_spaces']['operators'] = ['|' => null];
+		}
+
+		return $rules;
 	}
 }


### PR DESCRIPTION
Add a temporary workaround to avoid spaces between union types, when use PHP 8+.

Even if there's no official standard, in all documents union types have no spaces around `|` operator, e.g.

```php
<?php

// Whth this commit
function getBla(string|int|Stringable $param): string {
    ..........................
}

// Without this commit
function getFoo(string | int | Stringable $param): string {
    ..........................
}
``` 